### PR TITLE
download: if the lock file does not exist, error

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -26,7 +26,7 @@ var downloadCmd = &cobra.Command{
 func runFetch(cmd *cobra.Command, args []string) {
 	lockFile, err := cmd.Flags().GetString("lock-file")
 	FatalIfNotNil(err)
-	lock, err := internal.NewLock(lockFile, true)
+	lock, err := internal.NewLock(lockFile, false)
 	FatalIfNotNil(err)
 	dir, err := cmd.Flags().GetString("dir")
 	FatalIfNotNil(err)


### PR DESCRIPTION
## Description

If we `grabit download --lock-file foo` and the file `foo` does not exist, that should emit an error.  Likewise, if you `grabit download` and rely on the default `grabit.lock` file to exist, we should also error if that file does not exist.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
    * I'm happy to document it, but I'm not sure where is appropriate.
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
