### PR TITLE
Read files in chunks to avoid reading entire files in memory

### DIFF
--- a/internal/resource_test.go
+++ b/internal/resource_test.go
@@ -41,11 +41,11 @@ func TestNewResourceFromUrl(t *testing.T) {
 
 	for _, data := range tests {
 		resource, err := NewResourceFromUrl(data.urls, algo, []string{}, "")
-		assert.Equal(t, err == nil, data.valid)
+		assert.Equal(t, data.valid, err == nil)
 		if err != nil {
 			assert.Contains(t, err.Error(), data.errorContains)
 		} else {
-			assert.Equal(t, *resource, data.res)
+			assert.Equal(t, data.res, *resource)
 		}
 	}
 }

--- a/internal/sri_test.go
+++ b/internal/sri_test.go
@@ -35,11 +35,11 @@ func TestGetAlgoFromIntegrity(t *testing.T) {
 
 	for _, data := range tests {
 		algo, err := getAlgoFromIntegrity(data.sriString)
-		assert.Equal(t, err == nil, data.valid)
+		assert.Equal(t, data.valid, err == nil)
 		if err != nil {
 			assert.Contains(t, err.Error(), data.errorContains)
 		} else {
-			assert.Equal(t, algo, data.resString)
+			assert.Equal(t, data.resString, algo)
 		}
 	}
 }
@@ -48,7 +48,7 @@ func TestGetIntegrityFromFile(t *testing.T) {
 	path := tmpFile(t, "abcdef")
 	sri, err := getIntegrityFromFile(path, "sha256")
 	assert.Nil(t, err)
-	assert.Equal(t, sri, "sha256-vvV+x/U6bUC+tkCngKY5yDvCmsipgW8fxsXG3Nk8RyE=")
+	assert.Equal(t, "sha256-vvV+x/U6bUC+tkCngKY5yDvCmsipgW8fxsXG3Nk8RyE=", sri)
 }
 
 func TestCheckIntegrityFromFile(t *testing.T) {


### PR DESCRIPTION
Drive-by: fix the ordering of the parameters to asset.Equals, the
  expected value is supposed to be first.