### PR TITLE
Progress Bar Draft

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -10,6 +10,11 @@ import (
 
 func init() {
 	rootCmd.AddCommand(downloadCmd)
+
+	//Bar will not show unless --bar flag is used.
+	downloadCmd.Flags().Bool("bar", false, "Display progress bar during download")
+	downloadCmd.Flags().Lookup("bar").NoOptDefVal = "true"
+
 	downloadCmd.Flags().String("dir", ".", "Target directory where to store the files")
 	downloadCmd.Flags().StringArray("tag", []string{}, "Only download the resources with the given tag")
 	downloadCmd.Flags().StringArray("notag", []string{}, "Only download the resources without the given tag")
@@ -36,6 +41,8 @@ func runFetch(cmd *cobra.Command, args []string) {
 	FatalIfNotNil(err)
 	perm, err := cmd.Flags().GetString("perm")
 	FatalIfNotNil(err)
-	err = lock.Download(dir, tags, notags, perm)
+	bar, err := cmd.Flags().GetBool("bar")
+	FatalIfNotNil(err)
+	err = lock.Download(dir, tags, notags, perm, bar)
 	FatalIfNotNil(err)
 }

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -11,9 +11,9 @@ import (
 func init() {
 	rootCmd.AddCommand(downloadCmd)
 
-	//Progress bar will not show unless "--progress-bar" or "-p" flag is used.
-	downloadCmd.Flags().BoolP("progress-bar", "p", false, "Display progress bar during download")
-	downloadCmd.Flags().Lookup("progress-bar").NoOptDefVal = "true"
+	//Progress bar and accompanying status updates will not show unless "--status" or "-s" flag is used.
+	downloadCmd.Flags().BoolP("status", "s", false, "Continuously display bytes/resources downloaded, time elapsed, and progress bar")
+	downloadCmd.Flags().Lookup("status").NoOptDefVal = "true"
 
 	downloadCmd.Flags().String("dir", ".", "Target directory where to store the files")
 	downloadCmd.Flags().StringArray("tag", []string{}, "Only download the resources with the given tag")
@@ -41,7 +41,7 @@ func runFetch(cmd *cobra.Command, args []string) {
 	FatalIfNotNil(err)
 	perm, err := cmd.Flags().GetString("perm")
 	FatalIfNotNil(err)
-	bar, err := cmd.Flags().GetBool("progress-bar")
+	bar, err := cmd.Flags().GetBool("status")
 	FatalIfNotNil(err)
 	err = lock.Download(dir, tags, notags, perm, bar)
 	FatalIfNotNil(err)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -11,9 +11,9 @@ import (
 func init() {
 	rootCmd.AddCommand(downloadCmd)
 
-	//Bar will not show unless --bar flag is used.
-	downloadCmd.Flags().Bool("bar", false, "Display progress bar during download")
-	downloadCmd.Flags().Lookup("bar").NoOptDefVal = "true"
+	//Progress bar will not show unless "--progress-bar" or "-p" flag is used.
+	downloadCmd.Flags().BoolP("progress-bar", "p", false, "Display progress bar during download")
+	downloadCmd.Flags().Lookup("progress-bar").NoOptDefVal = "true"
 
 	downloadCmd.Flags().String("dir", ".", "Target directory where to store the files")
 	downloadCmd.Flags().StringArray("tag", []string{}, "Only download the resources with the given tag")
@@ -41,7 +41,7 @@ func runFetch(cmd *cobra.Command, args []string) {
 	FatalIfNotNil(err)
 	perm, err := cmd.Flags().GetString("perm")
 	FatalIfNotNil(err)
-	bar, err := cmd.Flags().GetBool("bar")
+	bar, err := cmd.Flags().GetBool("progress-bar")
 	FatalIfNotNil(err)
 	err = lock.Download(dir, tags, notags, perm, bar)
 	FatalIfNotNil(err)

--- a/internal/ansi_color.go
+++ b/internal/ansi_color.go
@@ -1,16 +1,19 @@
 package internal
 
-// ANSII color codes.
+// ANSI color codes.
 var clear = "\033[0m"
-var red = "\033[31"
 var green = "\033[32"
 var yellow = "\033[33"
+
+/*
+var red = "\033[31"
 var blue = "\033[34"
 var magenta = "\033[35"
 var cyan = "\033[36"
 var gray = "\033[37"
 var white = "\033[97"
 var bold_suffix = ";1m"
+*/
 var reg_suffix = "m"
 
 // Use to get colored text for printing to terminal.

--- a/internal/ansii_color.go
+++ b/internal/ansii_color.go
@@ -1,0 +1,32 @@
+package internal
+
+// ANSII color codes.
+var clear = "\033[0m"
+var red = "\033[31"
+var green = "\033[32"
+var yellow = "\033[33"
+var blue = "\033[34"
+var magenta = "\033[35"
+var cyan = "\033[36"
+var gray = "\033[37"
+var white = "\033[97"
+var bold_suffix = ";1m"
+var reg_suffix = "m"
+
+// Use to get colored text for printing to terminal.
+// Returns "<color_code> <str> <clear>"
+// Ex: Color_Test("Hello", "green") returns "\033[32mHello\033[0m"
+func Color_Text(str string, color string) string {
+	var colStr string
+	if color == "green" {
+		colStr += green
+	} else if color == "yellow" {
+		colStr += yellow
+	} else {
+		//Invalid color provided.
+		return str
+	}
+
+	colStr += reg_suffix + str + clear
+	return colStr
+}

--- a/internal/lock.go
+++ b/internal/lock.go
@@ -150,15 +150,14 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string)
 	}
 	errorCh := make(chan error, total)
 
-	/*CAPSTONE vvvvv*/
 	//This progress goroutine will run concurrently with the download goroutines.
 	//When each download goroutine is finished, it places a 1 in the progressCh channel.
-	//The progress goroutine keeps a tally of how many downloads have finished by adding whatever is in the channel to the total.
+	//The progress goroutine keeps a tally of how many downloads have finished by adding whatever is in the channel to the total (a 1 for each completed download).
 	//Example:
-	//7 of 11 Complete   [■■■■■■■#___]
+	//[■■■■■■■#___]   7 of 11 Complete
 	//		■   completed download
 	//		#   current, active download
-	//		_	download yet to be started.
+	//		_	download yet to be started
 	progressCh := make(chan int)
 	go func() {
 		downloadTotal := 0
@@ -179,14 +178,13 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string)
 			}
 
 			bar += "]"
-			fmt.Printf("\r%v of %v Complete   "+bar, downloadTotal, len(filteredResources)) //"\r" allows the progress bar to clear and update on one line.
+			fmt.Printf("\r"+bar+"   %v of %v Complete", downloadTotal, len(filteredResources)) //"\r" allows the progress bar to clear and update on one line.
 			if downloadTotal == len(filteredResources) {
 				fmt.Println()
 				break
 			}
 		}
 	}()
-	/*CAPSTONE ^^^^^*/
 
 	for _, r := range filteredResources {
 		resource := r
@@ -195,9 +193,7 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string)
 
 			errorCh <- err
 
-			/*CAPSTONE vvvvv*/
 			progressCh <- 1
-			/*CAPSTONE ^^^^^*/
 		}()
 	}
 	done := 0

--- a/internal/lock.go
+++ b/internal/lock.go
@@ -154,6 +154,8 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 
 	progressCh := make(chan int)
 	if bar {
+		startTime := time.Now()
+
 		spinChars := [5]string{"-", "\\", "|", "/", "-"}
 		spinI := 0 //Current char in spinChars.
 
@@ -240,10 +242,12 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 				}
 				completeStr := strconv.Itoa(downloadTotal) + "/" + strconv.Itoa(len(filteredResources)) + " Complete"
 
+				elapsedStr := strconv.Itoa(int(time.Now().Sub(startTime).Round(time.Second).Seconds())) + "s Elapsed"
+
 				//Build and print line.
 				//"\r" allows the bar to clear and update on one line.
 				pad := "          "
-				line := "\r" + spinner + barStr + pad + completeStr + pad + byteStr
+				line := "\r" + spinner + barStr + pad + completeStr + pad + byteStr + pad + elapsedStr
 				fmt.Print(Color_Text(line, color))
 
 				if downloadTotal == len(filteredResources) {

--- a/internal/lock.go
+++ b/internal/lock.go
@@ -178,6 +178,7 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 			for {
 				downloadTotal += <-progressCh
 
+				//Spinner loops through chars in spinChars to give impression it's rotating.
 				var spinner string
 				if downloadTotal < len(filteredResources) {
 					spinner = spinChars[spinI]
@@ -197,6 +198,7 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 					color = "green"
 				}
 
+				//Build progress bar string.
 				bar := "║"
 				for i := 0; i < downloadTotal; i += 1 {
 					bar += "█"
@@ -209,9 +211,9 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 				for i := downloadTotal + 1; i < len(filteredResources); i += 1 {
 					bar += "_"
 				}
-
 				bar += "║"
 
+				//Build and print line.
 				//"\r" allows the bar to clear and update on one line.
 				line := "\r" + spinner + bar + "   " + strconv.Itoa(downloadTotal) + "/" + strconv.Itoa(len(filteredResources)) + " Complete"
 				fmt.Print(Color_Text(line, color))

--- a/internal/lock.go
+++ b/internal/lock.go
@@ -165,6 +165,14 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 			for {
 				downloadTotal += <-progressCh
 
+				//Bar is yellow while downloading, green when complete.
+				var color string
+				if downloadTotal < len(filteredResources) {
+					color = "yellow"
+				} else {
+					color = "green"
+				}
+
 				bar := "["
 				for i := 0; i < downloadTotal; i += 1 {
 					bar += "■"
@@ -179,7 +187,11 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 				}
 
 				bar += "]"
-				fmt.Printf("\r"+bar+"    %v of %v Complete", downloadTotal, len(filteredResources)) //"\r" allows the progress bar to clear and update on one line.
+
+				//"\r" allows the bar to clear and update on one line.
+				line := "\r" + bar + "   " + strconv.Itoa(downloadTotal) + " of " + strconv.Itoa(len(filteredResources)) + " Complete"
+				fmt.Print(Color_Text(line, color))
+
 				if downloadTotal == len(filteredResources) {
 					fmt.Println()
 					break

--- a/internal/lock.go
+++ b/internal/lock.go
@@ -164,6 +164,9 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 		spinChars := [6]string{"-", "\\", "|", "/", "-", "\\"}
 		spinI := 0 //Current char in spinChars.
 
+		dotChars := [4]string{"   ", ".  ", ".. ", "..."}
+		dotI := 0
+
 		//The progress bar goroutine blocks and waits for items to enter the progressCh channel.
 		//So the spinner would only update when a download completes (when a download completes, it places a 1 in progressCh)
 		//We want the spinner to continuously update, so we continuously feed in 0's to the progressCh channel (every 50 milliseconds).
@@ -194,6 +197,15 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 					spinner = "✔"
 				}
 
+				//Ellipsis dots should tick slower than spinner.
+				//Ellipsis will tick every interval spinner ticks.
+				interval := 15
+				dots := dotChars[dotI/interval]
+				dotI += 1
+				if dotI == interval*len(dotChars)-1 {
+					dotI = 0
+				}
+
 				//Bar is yellow while downloading, green when complete.
 				var color string
 				if downloadTotal < len(filteredResources) {
@@ -218,7 +230,14 @@ func (l *Lock) Download(dir string, tags []string, notags []string, perm string,
 				bar += "]"
 
 				//"\r" allows the bar to clear and update on one line.
-				line := "\r" + spinner + bar + "   " + strconv.Itoa(downloadTotal) + " of " + strconv.Itoa(len(filteredResources)) + " Complete"
+				var grab string
+				if downloadTotal < len(filteredResources) {
+					grab = "Grabbing it" + dots
+				} else {
+					grab = "Grabbed!      "
+				}
+				line := "\r" + grab + "\t\t" + spinner + bar + "\t\t" + strconv.Itoa(downloadTotal) + " of " + strconv.Itoa(len(filteredResources)) + " Complete"
+				fmt.Print("\b\b\b\b")
 				fmt.Print(Color_Text(line, color))
 
 				if downloadTotal == len(filteredResources) {

--- a/internal/lock_test.go
+++ b/internal/lock_test.go
@@ -114,7 +114,7 @@ func TestDownload(t *testing.T) {
 	lock, err := NewLock(path, false)
 	assert.Nil(t, err)
 	dir := tmpDir(t)
-	err = lock.Download(dir, []string{}, []string{}, perm)
+	err = lock.Download(dir, []string{}, []string{}, perm, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Added "--bar" flag to "download" command to display progress bar. 
- Each "cell" in the bar represents a resource. Bar fills as resources are downloaded. 
- Added support for outputting colored text to terminal via ANSI codes (if colored text is not at all desired, let me know and I can remove it).
- A single-char ASCII spinner gives the user a sense of movement/productivity -- helps relieve the impression that the program has crashed/stopped during large downloads when the progress bar is idle. 

(This doesn't include the "--bar" flag change)
