### PR TITLE
Progress bar (status line)

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -15,6 +15,8 @@ func addDownload(cmd *cobra.Command) {
 		Args:  cobra.NoArgs,
 		RunE:  runFetch,
 	}
+	downloadCmd.Flags().BoolP("status", "s", false, "Continuously display bytes/resources downloaded, time elapsed, and progress bar")
+	downloadCmd.Flags().Lookup("status").NoOptDefVal = "true"
 	downloadCmd.Flags().String("dir", ".", "Target directory where to store the files")
 	downloadCmd.Flags().StringArray("tag", []string{}, "Only download the resources with the given tag")
 	downloadCmd.Flags().StringArray("notag", []string{}, "Only download the resources without the given tag")
@@ -47,7 +49,11 @@ func runFetch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = lock.Download(dir, tags, notags, perm)
+	status, err := cmd.Flags().GetBool("status")
+	if err != nil {
+		return err
+	}
+	err = lock.Download(dir, tags, notags, perm, status)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.0
 
 require (
 	github.com/carlmjohnson/requests v0.24.2
+	github.com/dustin/go-humanize v1.0.1
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
@@ -14,7 +15,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/lock_test.go
+++ b/internal/lock_test.go
@@ -115,7 +115,7 @@ func TestDownload(t *testing.T) {
 	lock, err := NewLock(path, false)
 	assert.Nil(t, err)
 	dir := test.TmpDir(t)
-	err = lock.Download(dir, []string{}, []string{}, perm)
+	err = lock.Download(dir, []string{}, []string{}, perm, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/status.go
+++ b/internal/status.go
@@ -1,0 +1,154 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/rs/zerolog/log"
+)
+
+type StatusLine struct {
+	resources              *[]Resource
+	resourceSizes          []int64
+	totalBytes             int64
+	numBytesDownloaded     int64
+	numResourcesDownloaded int
+	spinI                  int
+	isRunning              atomic.Bool
+	startTime              time.Time
+	sizingErr              error
+	ctx                    context.Context
+	mtx                    sync.RWMutex
+}
+
+const spinChars = "-\\|/"
+const tickMs = 50
+const timeoutMs = 1000
+
+// NewStatusLine creates and initializes a new StatusLine.
+func NewStatusLine(ctx context.Context, resources *[]Resource) *StatusLine {
+	st := StatusLine{}
+	st.resources = resources
+	st.ctx = ctx
+	return &st
+}
+
+// Increment informs the StatusLine that a resource (at index i in resource list) has finished downloading.
+// The SL is printed and Stopped if all resources are downloaded.
+func (st *StatusLine) Increment(i int) {
+	st.mtx.Lock()
+	st.numBytesDownloaded += st.resourceSizes[i]
+	st.numResourcesDownloaded++
+	st.mtx.Unlock()
+
+	fmt.Print(st.GetStatusString() + " ")
+	if st.numResourcesDownloaded == len(*st.resources) {
+		fmt.Println()
+		st.Stop()
+		return
+	}
+}
+
+// Start begins the goroutine and loop that will update/print the status line.
+// Pass true to force SL to update (spinner and second counter) every 50ms.
+func (st *StatusLine) Start(doTick bool) {
+	st.isRunning.Store(true)
+	st.startTime = time.Now()
+	go func() {
+		fmt.Print(st.GetStatusString())
+		for {
+			select {
+			case <-st.ctx.Done():
+				st.Stop()
+				return
+			case <-time.After(tickMs * time.Millisecond):
+				if !doTick {
+					continue
+				}
+			}
+
+			st.mtx.Lock()
+			st.spinI = (st.spinI + 1) % len(spinChars)
+			st.mtx.Unlock()
+
+			fmt.Print(st.GetStatusString() + " ")
+		}
+	}()
+
+}
+
+func (st *StatusLine) Stop() {
+	st.isRunning.Store(false)
+}
+
+// initResourceSizes fetches the size, in bytes, of each resource.
+func (st *StatusLine) InitResourcesSizes() error {
+	log.Debug().Msg("Fetching resource sizes")
+	st.resourceSizes = make([]int64, len(*st.resources))
+	for i := 0; i < len(st.resourceSizes); i++ {
+		st.resourceSizes[i] = 0
+	}
+
+	st.totalBytes = 0
+	for i, r := range *st.resources {
+		resource := r
+		httpClient := &http.Client{Timeout: time.Duration(timeoutMs) * time.Millisecond}
+		resp, err := httpClient.Head(resource.Urls[0])
+		if err != nil {
+			log.Debug().Msg("Error fetching resource sizes")
+			return err
+		}
+		st.totalBytes += resp.ContentLength
+		st.resourceSizes[i] = resp.ContentLength
+	}
+
+	return nil
+}
+
+// GetStatusString composes and returns the status line string for printing.
+func (st *StatusLine) GetStatusString() string {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+
+	var spinner string
+	if st.numResourcesDownloaded < len(*st.resources) {
+		spinner = string(spinChars[st.spinI])
+	} else {
+		spinner = "✔"
+	}
+
+	barStr := "["
+	if st.sizingErr == nil && st.totalBytes > 0 {
+		barLength := 20
+		if st.totalBytes < 20 {
+			barLength = int(st.totalBytes)
+		}
+		squareSize := st.totalBytes / int64(barLength)
+		for i := 0; i < int(st.numBytesDownloaded/squareSize); i += 1 {
+			barStr += "█"
+		}
+		for i := int(st.numBytesDownloaded / squareSize); i < barLength; i += 1 {
+			barStr += " "
+		}
+	}
+	barStr += "]"
+
+	completeStr := strconv.Itoa(st.numResourcesDownloaded) + "/" + strconv.Itoa(len(*st.resources)) + " Resources"
+	byteStr := humanize.Bytes(uint64(st.numBytesDownloaded)) + " / " + humanize.Bytes(uint64(st.totalBytes))
+	elapsedStr := strconv.Itoa(int(time.Since(st.startTime).Round(time.Second).Seconds())) + "s elapsed"
+
+	pad := "          "
+	var line string
+	if st.sizingErr == nil {
+		line = "\r" + spinner + barStr + pad + completeStr + pad + byteStr + pad + elapsedStr // "\r" lets us clear the line.
+	} else {
+		line = "\r" + spinner + "[]" + pad + completeStr + pad + elapsedStr
+	}
+	return line
+}

--- a/internal/status_test.go
+++ b/internal/status_test.go
@@ -1,0 +1,111 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cisco-open/grabit/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpinner(t *testing.T) {
+	resources := createResources(1, t)
+	ctx, _ := context.WithCancel(context.Background())
+	sl := NewStatusLine(ctx, &resources)
+	err := sl.InitResourcesSizes()
+	assert.Nil(t, err)
+
+	sl.Start(true)
+	assert.Equal(t, "\r-[      ]          0/1 Resources          0 B / 6 B          0s elapsed", sl.GetStatusString())
+	time.Sleep(60 * time.Millisecond) // Give extra ms to allow SL to update.
+	assert.Equal(t, "\r\\[      ]          0/1 Resources          0 B / 6 B          0s elapsed", sl.GetStatusString())
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, "\r|[      ]          0/1 Resources          0 B / 6 B          0s elapsed", sl.GetStatusString())
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, "\r/[      ]          0/1 Resources          0 B / 6 B          0s elapsed", sl.GetStatusString())
+	time.Sleep(60 * time.Millisecond)
+	assert.Equal(t, "\r-[      ]          0/1 Resources          0 B / 6 B          0s elapsed", sl.GetStatusString())
+}
+
+func TestTimer(t *testing.T) {
+	resources := createResources(1, t)
+	ctx, _ := context.WithCancel(context.Background())
+	sl := NewStatusLine(ctx, &resources)
+	err := sl.InitResourcesSizes()
+	assert.Nil(t, err)
+
+	sl.Start(false)
+	assert.Equal(t, "\r-[      ]          0/1 Resources          0 B / 6 B          0s elapsed", sl.GetStatusString())
+	time.Sleep(1000 * time.Millisecond)
+	assert.Equal(t, "\r-[      ]          0/1 Resources          0 B / 6 B          1s elapsed", sl.GetStatusString())
+	time.Sleep(1000 * time.Millisecond)
+	assert.Equal(t, "\r-[      ]          0/1 Resources          0 B / 6 B          2s elapsed", sl.GetStatusString())
+}
+
+func TestCountersWith2Resources(t *testing.T) {
+	resources := createResources(2, t)
+	ctx, _ := context.WithCancel(context.Background())
+	sl := NewStatusLine(ctx, &resources)
+	err := sl.InitResourcesSizes()
+	assert.Nil(t, err)
+
+	sl.Start(false)
+	assert.Equal(t, "\r-[            ]          0/2 Resources          0 B / 12 B          0s elapsed", sl.GetStatusString())
+	sl.Increment(0)
+	assert.Equal(t, "\r-[██████      ]          1/2 Resources          6 B / 12 B          0s elapsed", sl.GetStatusString())
+	sl.Increment(1)
+	assert.Equal(t, "\r✔[████████████]          2/2 Resources          12 B / 12 B          0s elapsed", sl.GetStatusString())
+
+}
+
+func TestCountersWith1000Resources(t *testing.T) {
+	resources := createResources(1000, t)
+	ctx, _ := context.WithCancel(context.Background())
+	sl := NewStatusLine(ctx, &resources)
+	err := sl.InitResourcesSizes()
+	assert.Nil(t, err)
+
+	sl.Start(false)
+	assert.Equal(t, "\r-[                    ]          0/1000 Resources          0 B / 6.0 kB          0s elapsed", sl.GetStatusString())
+	sl.Increment(0)
+	assert.Equal(t, "\r-[                    ]          1/1000 Resources          6 B / 6.0 kB          0s elapsed", sl.GetStatusString())
+	sl.Increment(1)
+	assert.Equal(t, "\r-[                    ]          2/1000 Resources          12 B / 6.0 kB          0s elapsed", sl.GetStatusString())
+	sl.Increment(2)
+	assert.Equal(t, "\r-[                    ]          3/1000 Resources          18 B / 6.0 kB          0s elapsed", sl.GetStatusString())
+	sl.Increment(3)
+	assert.Equal(t, "\r-[                    ]          4/1000 Resources          24 B / 6.0 kB          0s elapsed", sl.GetStatusString())
+	for i := 4; i < 1000; i++ {
+		sl.Increment(i)
+	}
+	assert.Equal(t, sl.GetStatusString(), "\r✔[████████████████████]          1000/1000 Resources          6.0 kB / 6.0 kB          0s elapsed")
+}
+
+func TestWithCancelledContext(t *testing.T) {
+	resources := createResources(2, t)
+	ctx, cancel := context.WithCancel(context.Background())
+	sl := NewStatusLine(ctx, &resources)
+	err := sl.InitResourcesSizes()
+	assert.Nil(t, err)
+
+	assert.Equal(t, false, sl.isRunning.Load())
+	sl.Start(false)
+	sl.Increment(0)
+	cancel()
+	time.Sleep(10 * time.Millisecond) // Give SL time to Stop.
+	assert.NotEqual(t, true, sl.isRunning.Load())
+}
+
+func createResources(num int, t *testing.T) []Resource {
+	content := `abcdef`
+	port := test.TestHttpHandler(content, t)
+	resources := []Resource{}
+	algo := "sha256"
+	for i := 0; i < num; i++ {
+		resource := Resource{Urls: []string{fmt.Sprintf("http://localhost:%d/test%d.html", port, i)}, Integrity: fmt.Sprintf("%s-vvV+x/U6bUC+tkCngKY5yDvCmsipgW8fxsXG3Nk8RyE=", algo), Tags: []string{}, Filename: ""}
+		resources = append(resources, resource)
+	}
+	return resources
+}


### PR DESCRIPTION
The download command has a new flag: --status (-s for shorthand)

Upon executing the download command with this new flag, a line will appear that displays updating metrics. 
Examples: 
      -[___________]          1/1000 Resources          6 B / 6.0 kB          0s elapsed
   ✔[██████]          1/1 Resources          6 B / 6 B          0s elapsed


- The user is shown how many resources have completed downloading (numerically with "#/# Resources" and visually with the bar), how many bytes have downloaded and the total size of all resources, and how much time has elapsed.
- The byte counter, resource counter, and bar update when a resource finishes downloading.
- The ASCII spinner and seconds counter continuously update.
