### PR TITLE
status.go: fix cosmetic issue

### DIFF
--- a/internal/status.go
+++ b/internal/status.go
@@ -67,6 +67,7 @@ func (st *StatusLine) Start(doTick bool) {
 			select {
 			case <-st.ctx.Done():
 				st.Stop()
+				fmt.Println()
 				return
 			case <-time.After(tickMs * time.Millisecond):
 				if !doTick {


### PR DESCRIPTION
## Description

Ensure to emit a \n at the end of the status line when the download has finished.  Other code paths already do this; this code path was missed.

Fixes #36.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
